### PR TITLE
Add configuration to choose import format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [1.0.0]
 
 - Initial release
+
+## [1.1.0]
+
+- New import type

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# fp-ts Import Helper README
+# fp-ts Import README
+
+    fork from https://github.com/SilentEchoGM/fp-ts-import-helper
 
 This extension exists purely to save me the hassle of importing modules from fp-ts and aliasing them via snippets or manual typing.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "fpts-import-helper",
-  "version": "0.0.1",
+  "name": "fp-ts-import",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "fpts-import-helper",
-      "version": "0.0.1",
+      "name": "fp-ts-import",
+      "version": "1.0.1",
       "dependencies": {
         "fp-ts": "^2.16.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,23 @@
   "activationEvents": [],
   "main": "./out/main.js",
   "contributes": {
+    "configuration": {
+      "title": "fp-ts Import Helper",
+      "properties": {
+        "fpts-import-helper.importFormat": {
+          "type": "string",
+          "default": "module",
+          "enum": [
+            "root",
+            "module"
+          ],
+          "enumDescriptions": [
+            "Import from root (eg: import { Array as A } from \"fp-ts\";)",
+            "Import from module (eg: import * as A from \"fp-ts/Array\";)"
+          ]
+        }
+      }
+    },
     "languages": [
       {
         "id": "typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fpts-import-helper",
-  "displayName": "fp-ts Import Helper",
+  "name": "fp-ts-import",
+  "displayName": "fp-ts Import",
   "description": "Automatically aliases fp-ts module imports to abbreviations",
   "version": "1.0.1",
   "engines": {
@@ -18,9 +18,9 @@
   "main": "./out/main.js",
   "contributes": {
     "configuration": {
-      "title": "fp-ts Import Helper",
+      "title": "fp-ts Import",
       "properties": {
-        "fpts-import-helper.importFormat": {
+        "fpts-import.importFormat": {
           "type": "string",
           "default": "module",
           "enum": [
@@ -81,6 +81,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SilentEchoGM/fp-ts-import-helper"
+    "url": "https://github.com/ooga/fp-ts-import-helper"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "name": "Eoin \"Silent Echo\" Bathurst",
     "email": "silent@silentecho.eu"
   },
-  "publisher": "silentechogm",
+  "publisher": "ooga",
   "activationEvents": [],
   "main": "./out/main.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "configuration": {
       "title": "fp-ts Import",
       "properties": {
-        "fpts-import.importFormat": {
+        "fp-ts-import.importFormat": {
           "type": "string",
           "default": "module",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fp-ts-import",
   "displayName": "fp-ts Import",
   "description": "Automatically aliases fp-ts module imports to abbreviations",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "engines": {
     "vscode": "^1.80.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,8 @@
 import * as vscode from "vscode";
 
-import {
-  array as A,
-  record as R,
-  function as f
-} from "fp-ts";
+import * as A from "fp-ts/Array";
+import * as R from "fp-ts/Record";
+import { pipe } from "fp-ts/function";
 
 const dict = {
   RA: "readonlyArray",
@@ -32,7 +30,7 @@ const dict = {
 };
 export function activate(context: vscode.ExtensionContext) {
   const importFormat = vscode.workspace
-    .getConfiguration("fpts-import-helper")
+    .getConfiguration("fp-ts-import")
     .get("importFormat");
   const completion = vscode.languages.registerCompletionItemProvider(
     "typescript",
@@ -67,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
           return completion;
         };
 
-        return f.pipe(
+        return pipe(
           dict,
           R.keys,
           A.map((mod) => addCompletion(mod))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,8 @@ const dict = {
   T: "task",
   TE: "taskEither",
   TO: "taskOption",
-  O: "option",FRandom: "random",
+  O: "option",
+  FRandom: "random",
   N: "number",
   E: "either",
   A: "array",
@@ -30,6 +31,9 @@ const dict = {
   These: "these",
 };
 export function activate(context: vscode.ExtensionContext) {
+  const importFormat = vscode.workspace
+    .getConfiguration("fpts-import-helper")
+    .get("importFormat");
   const completion = vscode.languages.registerCompletionItemProvider(
     "typescript",
     {
@@ -47,7 +51,9 @@ export function activate(context: vscode.ExtensionContext) {
                 new vscode.Position(0, 0),
                 new vscode.Position(0, 0)
               ),
-              `import { ${dict[mod]} as ${mod} } from "fp-ts";\n`
+              importFormat === "module"
+                ? `import * as ${mod} from "fp-ts/${capitalize(dict[mod])}";\n`
+                : `import { ${dict[mod]} as ${mod} } from "fp-ts";\n`
             ),
           ];
           completion.kind = vscode.CompletionItemKind.Module;
@@ -71,4 +77,8 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(completion);
+}
+
+function capitalize(string: string) {
+  return string[0].toUpperCase() + string.slice(1);
 }


### PR DESCRIPTION
The [recommended way of importing](https://gcanti.github.io/fp-ts/guides/code-conventions.html#import-statements) is `import * as Option from 'fp-ts/Option'`

I just add a setting to choose the desired import format.

Thanks for this extension 👍 